### PR TITLE
Added prop for maxHeight

### DIFF
--- a/src/data-table.js
+++ b/src/data-table.js
@@ -6,7 +6,7 @@ const selectable = require('./selectable');
 const scrollable = require('./scrollable');
 const util = require('./util');
 
-const props = ['data', 'sort', 'selected', 'stretch-column'];
+const props = ['data', 'sort', 'selected', 'stretch-column', 'maxHeight'];
 const bools = ['sortable', 'selectable', 'scrollable', 'perf'];
 const PERF = true;
 let log;

--- a/src/data-table.js
+++ b/src/data-table.js
@@ -6,7 +6,7 @@ const selectable = require('./selectable');
 const scrollable = require('./scrollable');
 const util = require('./util');
 
-const props = ['data', 'sort', 'selected', 'stretch-column', 'maxHeight'];
+const props = ['data', 'sort', 'selected', 'stretch-column', 'max-height'];
 const bools = ['sortable', 'selectable', 'scrollable', 'perf'];
 const PERF = true;
 let log;

--- a/src/scrollable.js
+++ b/src/scrollable.js
@@ -18,8 +18,8 @@ const Scrollable = {
 			{
 				className: 'table-body-wrapper',
 				style: {
-					'max-height': this.maxHeight,
-					'position': this.maxHeight ? 'static' : 'absolute'
+					'max-height': this['max-height'],
+					'position': this['max-height'] ? 'static' : 'absolute'
 				}
 			}, this);
 		this.tableBody = dom('table', {className: 'table-body', tabindex:'1'}, this.tableBodyWrapper);

--- a/src/scrollable.js
+++ b/src/scrollable.js
@@ -14,7 +14,14 @@ const Scrollable = {
 		this.tableHeadWrapper = dom('div', {className: 'table-header-wrapper'}, this);
 		this.tableHeader = dom('table', {className: 'table-header', tabindex:'1'}, this.tableHeadWrapper);
 		this.thead = dom('thead', {}, this.tableHeader);
-		this.tableBodyWrapper = dom('div', {className: 'table-body-wrapper', style: { 'max-height': this.maxHeight }}, this);
+		this.tableBodyWrapper = dom('div',
+			{
+				className: 'table-body-wrapper',
+				style: {
+					'max-height': this.maxHeight,
+					'position': this.maxHeight ? 'static' : 'absolute'
+				}
+			}, this);
 		this.tableBody = dom('table', {className: 'table-body', tabindex:'1'}, this.tableBodyWrapper);
 		this.tbody = dom('tbody', {}, this.tableBody);
 	},

--- a/src/scrollable.js
+++ b/src/scrollable.js
@@ -14,7 +14,7 @@ const Scrollable = {
 		this.tableHeadWrapper = dom('div', {className: 'table-header-wrapper'}, this);
 		this.tableHeader = dom('table', {className: 'table-header', tabindex:'1'}, this.tableHeadWrapper);
 		this.thead = dom('thead', {}, this.tableHeader);
-		this.tableBodyWrapper = dom('div', {className: 'table-body-wrapper'}, this);
+		this.tableBodyWrapper = dom('div', {className: 'table-body-wrapper', style: { 'max-height': this.maxHeight }}, this);
 		this.tableBody = dom('table', {className: 'table-body', tabindex:'1'}, this.tableBodyWrapper);
 		this.tbody = dom('tbody', {}, this.tableBody);
 	},

--- a/tests/test.html
+++ b/tests/test.html
@@ -249,7 +249,7 @@
 				var node = dom('data-table', {
 					data: getData(),
 					scrollable: true,
-					maxHeight: '200px'
+					'max-height': 200
 				}, section);
 				onDomReady(node, function () {
 					done();

--- a/tests/test.html
+++ b/tests/test.html
@@ -244,6 +244,18 @@
 				});
 			});
 
+			test('it should be scrollable with maxHeight set', function (done) {
+				var section = dom('section', {}, body);
+				var node = dom('data-table', {
+					data: getData(),
+					scrollable: true,
+					maxHeight: '200px'
+				}, section);
+				onDomReady(node, function () {
+					done();
+				});
+			});
+
 			test('it should handle "no items"', function (done) {
 				var section = dom('section', { html: dom('label', { html: 'Items are []' }) }, body);
 				var node = dom('data-table', {
@@ -417,6 +429,8 @@
 					done();
 				});
 			});
+
+
 		});
 
 	});


### PR DESCRIPTION
Needed a better way to handle scrollable tables. Setting maxHeight on the container doesn't work, the table body needs to have the maxHeight set. If no maxHeight is supplied, it works as before. 